### PR TITLE
updated sinatra side logic

### DIFF
--- a/motor_on_voice-apis/intents/test.rb
+++ b/motor_on_voice-apis/intents/test.rb
@@ -6,38 +6,40 @@ intent "LaunchRequest" do
 end
 
 intent "MotorOnIntent" do
-  if Motor.running?
-    tell("Motor has already started running")
-  else
-    Motor.on(true)
-    case Motor.state
-    when 'running'
+  if Motor.connected?
+    if Motor.running?
+      tell("Motor has already started running")
+    else
+      Motor.on(true)
       tell("Starting motor now.")
-    when 'error'
-      tell("something went wrong, I couldn't start the motor")
     end
+  else
+    tell("something went wrong, I couldn't start the motor")
   end
 end
 
 intent "MotorOffIntent" do
-  if Motor.running?
-    Motor.on(false)
-    case Motor.state
-    when 'stopped'
+  if Motor.connected?
+    if Motor.running?
+      Motor.on(false)
       tell("Motor will be stopped now.")
-    when 'error'
-      tell("something went wrong, I couldn't stop the motor")
+    else
+      tell("Motor has already stopped running")
     end
   else
-    tell("Motor has already stopped running")
+    tell("something went wrong, I couldn't stop the motor")
   end
 end
 
 intent "MotorStatusIntent" do
-  if Motor.running?
-    ask("Motor is running. Do I need to stop motor now ?", session_attributes: { persist: "running" })
+  if Motor.connected?
+    if Motor.running?
+      ask("Motor is running. Do I need to stop motor now ?", session_attributes: { persist: "running" })
+    else
+      ask("motor is free for use. Do I need to start motor now ?", session_attributes: { persist: "not_running" })
+    end
   else
-    ask("motor is free for use. Do I need to start motor now ?", session_attributes: { persist: "not_running" })
+    tell("something went wrong, Please try check the motor connection and try again later")
   end
 end
 

--- a/motor_on_voice-apis/lib/motor.rb
+++ b/motor_on_voice-apis/lib/motor.rb
@@ -1,22 +1,46 @@
 require 'mqtt'
+require 'timeout'
 class Motor
   def intialize
     # `stopped` | `running` | `error`
     @state = 'stopped'
+    Motor.on(false)
   end
 
   def self.on(status)
-    @state = status
-    message = status ? "Run" : "Stop"
+    message = status ? "running" : "stopped"
     client = MqttClient.instance.client
-    client.publish('request', message)
-    client.get('response') do |topic, message|
-      # esp should return `running`/`stopped`/`error`
-      @state = message
+    client.publish('/request', message)
+    begin
+      Timeout.timeout(3){
+        client.get('/response') do |topic, message|
+            # esp should return `running`/`stopped`/`error`
+            @state = message
+            break
+        end
+      }
+    rescue Timeout::Error
+      @state = "error"
     end
   end
 
+  def self.connected?
+    client = MqttClient.instance.client
+    client.publish('/request', "connection_tester")
+    begin
+      Timeout.timeout(3){
+        client.get('/response') do |topic, message|
+          break
+        end
+      }
+    rescue Timeout::Error
+      @state = "error"
+      return false
+    end
+    return true
+  end
+
   def self.running?
-    @state == 'running'
+    @state == "running"
   end
 end


### PR DESCRIPTION
## changes 
- Added a `connection check` to microcontroller
  - `sinatra` side will `publish a message` 
   - `and` `wait` for the `response` 
   - `if` a response is `received` then the `connection is a success` otherwise failure

- Added `timeout` for the `MQTTresponse`

##  issue I personally feel
- connection check is done twice, which is good to ensure its success, but not sure whether it really requires twice 